### PR TITLE
Update httpx version pin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ fastapi
 uvicorn
 instagrapi
 Pillow
-httpx
+httpx<0.28


### PR DESCRIPTION
## Summary
- pin `httpx` dependency to `<0.28`

## Testing
- `pip install --force-reinstall -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d95f987bc8327adb76ccb7a3f013b