### PR TITLE
Update Dockerfile defaults

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
 FROM python:3.12-slim
 WORKDIR /app
+ENV PORT=8000
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
 # Configure DNS. Some build environments have a read-only resolv.conf, so
 # ignore any failure when writing the file.
 RUN echo 'nameserver 1.1.1.1\nnameserver 8.8.8.8' | tee /etc/resolv.conf >/dev/null || true
-CMD ["sh", "-c", "uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000}"]
+EXPOSE 8000
+CMD ["sh", "-c", "uvicorn app.main:app --host ${HOST:-0.0.0.0} --port ${PORT:-8000}"]

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ docker run -p 8000:8000 -e PORT=8000 instagram-vision
 
 ### Environment variables
 
-- `PORT` - port the server listens on (default `8000`). Set by Railway automatically.
+- `PORT` - port the server listens on (default `8000`). Railway sets this automatically when using the Dockerfile.
 - `HOST` - interface to bind to. Defaults to `0.0.0.0`.
 - `INSTAGRAM_USERNAME` and `INSTAGRAM_PASSWORD` - optional defaults used for login if provided.
 


### PR DESCRIPTION
## Summary
- expose default port and set `PORT` fallback
- document that Railway sets `PORT` automatically when using Dockerfile

## Testing
- `black . --line-length 120`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dba3438548327a9107be82af26588