### PR TITLE
Update Docker base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.11-slim
 WORKDIR /app
 ENV PORT=8000
 COPY requirements.txt .


### PR DESCRIPTION
## Summary
- use Python 3.11 slim image
- keep port 8000 exposed

## Testing
- `pytest -q`
- ❌ `docker build` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dbb48ccc48327b10a7d0d613ec4f2