### PR TITLE
Use PORT variable in Dockerfile start command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ COPY . .
 # ignore any failure when writing the file.
 RUN echo 'nameserver 1.1.1.1\nnameserver 8.8.8.8' | tee /etc/resolv.conf >/dev/null || true
 EXPOSE 8000
-CMD ["sh", "-c", "uvicorn app.main:app --host ${HOST:-0.0.0.0} --port ${PORT:-8000}"]
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "$PORT"]


### PR DESCRIPTION
## Summary
- use environment variable in start command in `Dockerfile`

## Testing
- `black . --check`
- `pytest -q`
- `PORT=1234 uvicorn app.main:app --host 0.0.0.0 --port $PORT`

------
https://chatgpt.com/codex/tasks/task_e_684dbccbf14c83279281e5f6f3f6025a